### PR TITLE
The Error When the Minute Part is Passed Empty

### DIFF
--- a/script.js
+++ b/script.js
@@ -11,10 +11,6 @@ let timerDisplay = document.getElementById('timer');
 function startTimer(duration) {
     let timer = duration * 60 + remainingTime;
     let minutes, seconds;
-
-    if(minutesInput == "NaN:NaN") {
-        console.log("input nan");
-    }
     
     timerInterval = setInterval(function () {
         minutes = Math.floor(timer / 60);
@@ -34,12 +30,16 @@ function startTimer(duration) {
 
 startButton.addEventListener('click', function () {
     let minutes = parseInt(minutesInput.value);
-    startTimer(minutes);
-    minutesInput.value = '';
-    startButton.disabled = true;
-    pauseButton.disabled = false;
-    resumeButton.disabled = true;
-    resetButton.disabled = false;
+    if(minutes ==) {
+        console.log("nan");
+    } else {
+        startTimer(minutes);
+        minutesInput.value = '';
+        startButton.disabled = true;
+        pauseButton.disabled = false;
+        resumeButton.disabled = true;
+        resetButton.disabled = false;
+    }
 });
 
 pauseButton.addEventListener('click', function () {

--- a/script.js
+++ b/script.js
@@ -30,9 +30,16 @@ function startTimer(duration) {
 
 startButton.addEventListener('click', function () {
     let minutes = parseInt(minutesInput.value);
-    if(minutes == "NaN") {
-        console.log("Geçersiz veri");
+    if(Number.isInteger(minutes) == false) {
+        clearInterval(timerInterval);
+        timerDisplay.textContent = '00:00';
+        minutesInput.value = '';
+        remainingTime = 0;
+        startButton.disabled = false;
+        pauseButton.disabled = true;
+        resumeButton.disabled = true;
     } else {
+        console.log(minutes);
         startTimer(minutes);
         minutesInput.value = '';
         startButton.disabled = true;
@@ -59,7 +66,7 @@ resumeButton.addEventListener('click', function () {
     resumeButton.disabled = true;
 });
 
-resetButton.addEventListener('click', function () {
+resetButton.addEventListener('click', function() {
     clearInterval(timerInterval);
     timerDisplay.textContent = '00:00';
     minutesInput.value = '';

--- a/script.js
+++ b/script.js
@@ -12,6 +12,10 @@ function startTimer(duration) {
     let timer = duration * 60 + remainingTime;
     let minutes, seconds;
 
+    if(document.getElementById('minutes') == 0) {
+        clearInterval(timerInterval);
+    }
+
     timerInterval = setInterval(function () {
         minutes = Math.floor(timer / 60);
         seconds = timer % 60;

--- a/script.js
+++ b/script.js
@@ -30,7 +30,7 @@ function startTimer(duration) {
 
 startButton.addEventListener('click', function () {
     let minutes = parseInt(minutesInput.value);
-    if(minutes == NaN) {
+    if(minutes == "NaN") {
         console.log("Geçersiz veri");
     } else {
         startTimer(minutes);

--- a/script.js
+++ b/script.js
@@ -12,8 +12,10 @@ function startTimer(duration) {
     let timer = duration * 60 + remainingTime;
     let minutes, seconds;
 
-    console.log(minutesInput);
-
+    if(minutesInput == "NaN:NaN") {
+        console.log("input nan");
+    }
+    
     timerInterval = setInterval(function () {
         minutes = Math.floor(timer / 60);
         seconds = timer % 60;

--- a/script.js
+++ b/script.js
@@ -12,9 +12,7 @@ function startTimer(duration) {
     let timer = duration * 60 + remainingTime;
     let minutes, seconds;
 
-    if(document.getElementById('minutes') == 0) {
-        clearInterval(timerInterval);
-    }
+    console.log(minutesInput);
 
     timerInterval = setInterval(function () {
         minutes = Math.floor(timer / 60);

--- a/script.js
+++ b/script.js
@@ -30,13 +30,16 @@ function startTimer(duration) {
 
 startButton.addEventListener('click', function () {
     let minutes = parseInt(minutesInput.value);
-    console.log(minutes);
+    if(minutes == NaN) {
+        console.log("Geçersiz veri");
+    } else {
         startTimer(minutes);
         minutesInput.value = '';
         startButton.disabled = true;
         pauseButton.disabled = false;
         resumeButton.disabled = true;
-        resetButton.disabled = false;
+        resetButton.disabled = false;   
+    }
 });
 
 pauseButton.addEventListener('click', function () {

--- a/script.js
+++ b/script.js
@@ -30,16 +30,13 @@ function startTimer(duration) {
 
 startButton.addEventListener('click', function () {
     let minutes = parseInt(minutesInput.value);
-    if(minutes ==) {
-        console.log("nan");
-    } else {
+    console.log(minutes);
         startTimer(minutes);
         minutesInput.value = '';
         startButton.disabled = true;
         pauseButton.disabled = false;
         resumeButton.disabled = true;
         resetButton.disabled = false;
-    }
 });
 
 pauseButton.addEventListener('click', function () {


### PR DESCRIPTION
When the number part was empty, it returned the `NaN:NaN` value. This issue has been completely fixed.